### PR TITLE
Import Markup from markupsafe

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish Python Package
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
 
 jobs:
   publish:
@@ -10,23 +12,19 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-
       - name: Install Flit
-        run: |
+        run: |-
           python -m pip install flit
-
       - name: Install Dependencies
-        run: |
+        run: |-
           python -m flit install --symlink
-
       - name: Publish to PyPI
         env:
           FLIT_USERNAME: __token__
           FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
+        run: |-
           python -m flit publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Bump package version and create release on Font Awesome library version upgrade
+name: Bump package version and create release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,4 +1,4 @@
-name: Upgrade Font Awesome library to the latest version
+name: Upgrade Font Awesome library
 
 on:
   workflow_dispatch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 requires-python = "~=3.8"
 dependencies = [
     "importlib-resources; python_version < '3.10'",
-    "flask"
+    "flask",
+    "markupsafe"
 ]
 dynamic = ["version", "description"]
 

--- a/src/flask_font_awesome/__init__.py
+++ b/src/flask_font_awesome/__init__.py
@@ -14,7 +14,7 @@ else:
 from flask import Blueprint, Flask, current_app, url_for
 from markupsafe import Markup
 
-__version__ = "0.1.6"
+__version__ = "0.1.5"
 
 STATIC_FOLDER = Path(files("flask_font_awesome") / "static")  # type: ignore
 DATA_DIR = Path(files("flask_font_awesome") / "data")  # type: ignore

--- a/src/flask_font_awesome/__init__.py
+++ b/src/flask_font_awesome/__init__.py
@@ -11,7 +11,8 @@ if sys.version_info < (3, 10):
 else:
     from importlib.resources import files
 
-from flask import Blueprint, Flask, Markup, current_app, url_for
+from flask import Blueprint, Flask, current_app, url_for
+from markupsafe import Markup
 
 __version__ = "0.1.5"
 

--- a/src/flask_font_awesome/__init__.py
+++ b/src/flask_font_awesome/__init__.py
@@ -14,7 +14,7 @@ else:
 from flask import Blueprint, Flask, current_app, url_for
 from markupsafe import Markup
 
-__version__ = "0.1.5"
+__version__ = "0.1.2"
 
 STATIC_FOLDER = Path(files("flask_font_awesome") / "static")  # type: ignore
 DATA_DIR = Path(files("flask_font_awesome") / "data")  # type: ignore

--- a/src/flask_font_awesome/__init__.py
+++ b/src/flask_font_awesome/__init__.py
@@ -14,7 +14,7 @@ else:
 from flask import Blueprint, Flask, current_app, url_for
 from markupsafe import Markup
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 STATIC_FOLDER = Path(files("flask_font_awesome") / "static")  # type: ignore
 DATA_DIR = Path(files("flask_font_awesome") / "data")  # type: ignore

--- a/src/flask_font_awesome/__init__.py
+++ b/src/flask_font_awesome/__init__.py
@@ -14,7 +14,7 @@ else:
 from flask import Blueprint, Flask, current_app, url_for
 from markupsafe import Markup
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 STATIC_FOLDER = Path(files("flask_font_awesome") / "static")  # type: ignore
 DATA_DIR = Path(files("flask_font_awesome") / "data")  # type: ignore


### PR DESCRIPTION
From Flask Version 3.0.0
> Importing escape and Markup from flask is deprecated. Import directly from markupsafe instead.

See [Flask changelog](https://flask.palletsprojects.com/en/3.0.x/changes/), precisely [https://github.com/pallets/flask/pull/5223](https://github.com/pallets/flask/pull/5223)